### PR TITLE
Update README.md to fixed mix-up in mode mapping.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ Each physical device appears within HomeKit Apps as two logical devices with the
 
 A Homekit Thermostat supports 4 states:
 * OFF: is mapped to the Ambi Climate's Off mode;
-* COOL: is mapped to the Away Temperature Lower mode i.e. keep the temperature below the set temperature;
-* HEAT: is mapped to the Away Temperature Upper mode i.e. keep the temperature above the set temperature;
+* COOL: is mapped to the Away Temperature Upper mode i.e. keep the temperature below the set temperature;
+* HEAT: is mapped to the Away Temperature Lower mode i.e. keep the temperature above the set temperature;
 * AUTO: is mapped to the Comfort mode.  In this mode the Homekit temperature setting has no influence.
 
 A separate plugin for Ambi Climate is available - [homebridge-ambiclimate](https://www.npmjs.com/package/homebridge-ambiclimate) exposes Ambi Climate devices as Temperature Sensor, Humidity Sensor, and Switch services within Homekit.


### PR DESCRIPTION
According to https://api.ambiclimate.com/doc/api#mode:

```
Away_Temperature_Lower: Away mode, keep temperature above value(float, Celsius).
Away_Temperature_Upper: Away mode, keep temperature below value(float, Celsius).
```

Also https://github.com/alisdairjsmyth/homebridge-ambiclimate-thermostat/blob/master/index.js#L174-L178